### PR TITLE
add getTotalCount

### DIFF
--- a/src/PostgresEngine.php
+++ b/src/PostgresEngine.php
@@ -405,4 +405,15 @@ class PostgresEngine extends Engine
     {
         return array_get($this->config, $key, $default);
     }
+
+    /**
+     * Get the total count from a raw result returned by the engine.
+     *
+     * @param  mixed  $results
+     * @return int
+     */
+    public function getTotalCount($results)
+    {
+        return count($results);
+    }
 }


### PR DESCRIPTION
I was receiving this error

```
Class ScoutEngines\Postgres\PostgresEngine contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (Laravel\Scout\Engines\Engine::getTotalCount)
```

Adding this to the PostgresEngine fixed it.
