### PR TITLE
Cast nulls to empty strings in `$fields` array, as well as `$select` string

### DIFF
--- a/src/PostgresEngine.php
+++ b/src/PostgresEngine.php
@@ -99,11 +99,11 @@ class PostgresEngine extends Engine
      */
     protected function toVector(Model $model)
     {
-        $fields = collect($model->toSearchableArray());
-
-        $select = $fields->map(function ($value) {
+        $fields = collect($model->toSearchableArray())->map(function ($value) {
             return $value === null ? '' : $value;
-        })->map(function ($_, $key) use ($model) {
+        });
+
+        $select = $fields->map(function ($_, $key) use ($model) {
             if ($label = $this->rankFieldWeightLabel($model, $key)) {
                 return "setweight(to_tsvector(?), '$label')";
             }

--- a/src/PostgresEngine.php
+++ b/src/PostgresEngine.php
@@ -2,11 +2,11 @@
 
 namespace ScoutEngines\Postgres;
 
-use Illuminate\Database\ConnectionResolverInterface;
-use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Database\Eloquent\Model;
 use Laravel\Scout\Builder;
 use Laravel\Scout\Engines\Engine;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\ConnectionResolverInterface;
 
 class PostgresEngine extends Engine
 {


### PR DESCRIPTION
Resolves an issue in `PostgresEngine::toVector`, where a null value in any searchable model field would result in a null `searchable` column.

Because null values were only mapped to empty strings in the `$select` string, but not in the `$fields` array, select statements such as

    SELECT setweight(to_tsvector('x'), 'A') || setweight(to_tsvector(null), 'B') AS tsvector

could be generated. But that `null` value in the second element propagates all the way up so that the end result is equivalent to

    SELECT null AS tsvector

---

To resolve this, I just moved the call to `map` on the searchable fields collection, so that its results are stored in the `$fields` array.