### PR TITLE
Update scout to 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "illuminate/contracts": "~5.3",
         "illuminate/database": "~5.3",
         "illuminate/support": "~5.3",
-        "laravel/scout": "^1.0"
+        "laravel/scout": "^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "5.*",

--- a/src/PostgresEngine.php
+++ b/src/PostgresEngine.php
@@ -224,6 +224,11 @@ class PostgresEngine extends Engine
             ->select($query->toSql(), $bindings->all());
     }
 
+    public function mapIds($results)
+    {
+        return collect($results)->pluck('id')->values()->all();
+    }
+
     /**
      * Map the given results to instances of the given model.
      *
@@ -238,11 +243,8 @@ class PostgresEngine extends Engine
         }
 
         $results = collect($results);
-
-        $keys = $results
-            ->pluck($model->getKeyName())
-            ->values()
-            ->all();
+        
+        $keys = $this->mapIds($results);
 
         $models = $model->whereIn($model->getKeyName(), $keys)
             ->get()

--- a/tests/PostgresEngineTest.php
+++ b/tests/PostgresEngineTest.php
@@ -136,6 +136,13 @@ class PostgresEngineTest extends AbstractTestCase
         $this->assertEquals(100, $count);
     }
 
+    public function test_map_ids_returns_right_key()
+    {
+        list($engine) = $this->getEngine();
+        $results = [new TestModel()];
+        $this->assertEquals([1], $engine->mapIds($results));
+    }
+
     protected function getEngine($config = [])
     {
         $resolver = Mockery::mock(ConnectionResolverInterface::class);


### PR DESCRIPTION
I'm trying to update the package so I can use it with newest version of scout.
For now I just implemented the abstract `mapIds` and added a simple test, everything seems to work but honestly I don't know what else is needed :smile: .