### PR TITLE
fix exception in collection if model use soft delete

### DIFF
--- a/src/PostgresEngine.php
+++ b/src/PostgresEngine.php
@@ -219,7 +219,7 @@ class PostgresEngine extends Engine
             ->orderBy($builder->model->getKeyName());
         //if model use soft delete - without trashed
         if(method_exists($builder->model, 'getDeletedAtColumn')) {
-            $query->where($builder->model->getDeletedAtColumn(),null);
+            $query->where($builder->model->getDeletedAtColumn(), null);
         }
         if ($perPage > 0) {
             $query->skip(($page - 1) * $perPage)

--- a/src/PostgresEngine.php
+++ b/src/PostgresEngine.php
@@ -218,7 +218,7 @@ class PostgresEngine extends Engine
             ->orderBy('rank', 'desc')
             ->orderBy($builder->model->getKeyName());
         //if model use soft delete - without trashed
-        if(method_exists($builder->model, 'getDeletedAtColumn')){
+        if(method_exists($builder->model, 'getDeletedAtColumn')) {
             $query->where($builder->model->getDeletedAtColumn(),null);
         }
         if ($perPage > 0) {

--- a/src/PostgresEngine.php
+++ b/src/PostgresEngine.php
@@ -217,7 +217,10 @@ class PostgresEngine extends Engine
             ->whereRaw("$indexColumn @@ query")
             ->orderBy('rank', 'desc')
             ->orderBy($builder->model->getKeyName());
-
+        //if model use soft delete - without trashed
+        if(method_exists($builder->model, 'getDeletedAtColumn')){
+            $query->where($builder->model->getDeletedAtColumn(),null);
+        }
         if ($perPage > 0) {
             $query->skip(($page - 1) * $perPage)
                 ->limit($perPage);

--- a/src/PostgresEngine.php
+++ b/src/PostgresEngine.php
@@ -218,7 +218,7 @@ class PostgresEngine extends Engine
             ->orderBy('rank', 'desc')
             ->orderBy($builder->model->getKeyName());
         //if model use soft delete - without trashed
-        if(method_exists($builder->model, 'getDeletedAtColumn')) {
+        if (method_exists($builder->model, 'getDeletedAtColumn')) {
             $query->where($builder->model->getDeletedAtColumn(), null);
         }
         if ($perPage > 0) {

--- a/tests/PostgresEngineTest.php
+++ b/tests/PostgresEngineTest.php
@@ -109,6 +109,7 @@ class PostgresEngineTest extends AbstractTestCase
             ->shouldReceive('limit')->with(5)->andReturnSelf()
             ->shouldReceive('where')->with('bar', 1)->andReturnSelf()
             ->shouldReceive('where')->with('deleted_at', null);
+        
         $db->shouldReceive('select')->with(null, ['foo', 1]);
 
         $builder = new Builder(new TestWithSoftDeleteModel(), 'foo');

--- a/tests/PostgresEngineTest.php
+++ b/tests/PostgresEngineTest.php
@@ -37,7 +37,7 @@ class PostgresEngineTest extends AbstractTestCase
         $table->shouldReceive('where')
             ->with('id', '=', 1)
             ->andReturnSelf();
-        
+
         $table->shouldReceive('update')
             ->with(['searchable' => 'foo']);
 
@@ -98,18 +98,18 @@ class PostgresEngineTest extends AbstractTestCase
 
         $engine->search($builder);
     }
-    
+
     public function test_search_with_soft_delete()
     {
         list($engine, $db) = $this->getEngine();
-        
+
         $table = $this->setDbExpectations($db);
-        
+
         $table->shouldReceive('skip')->with(0)->andReturnSelf()
             ->shouldReceive('limit')->with(5)->andReturnSelf()
             ->shouldReceive('where')->with('bar', 1)->andReturnSelf()
             ->shouldReceive('where')->with('deleted_at', null);
-        
+
         $db->shouldReceive('select')->with(null, ['foo', 1]);
 
         $builder = new Builder(new TestWithSoftDeleteModel(), 'foo');
@@ -188,7 +188,7 @@ class PostgresEngineTest extends AbstractTestCase
             ->shouldReceive('orderBy')->with('rank', 'desc')->andReturnSelf()
             ->shouldReceive('orderBy')->with('id')->andReturnSelf()
             ->shouldReceive('toSql');
-        
+
         return $table;
     }
 }
@@ -249,8 +249,8 @@ class TestModel extends Model
 }
 
 class TestWithSoftDeleteModel extends Model
-{    
-    use \Illuminate\Database\Eloquent\SoftDeletes;    
+{
+    use \Illuminate\Database\Eloquent\SoftDeletes;
     public $id = 1;
 
     public $text = 'Foo';

--- a/tests/PostgresEngineTest.php
+++ b/tests/PostgresEngineTest.php
@@ -249,9 +249,8 @@ class TestModel extends Model
 }
 
 class TestWithSoftDeleteModel extends Model
-{
-    use \Illuminate\Database\Eloquent\SoftDeletes;
-    
+{    
+    use \Illuminate\Database\Eloquent\SoftDeletes;    
     public $id = 1;
 
     public $text = 'Foo';


### PR DESCRIPTION
hello! if the model is used SoftDeletes and the model is removed, it throws an exception in the Illuminate\Database\Eloquent\Collection. I have added tracking availability SoftDeletes model