### PR TITLE
Add support for unaccent extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ return [
         'connection' => 'pgsql',
         'maintain_index' => true,
         'config' => 'english',
+        'unaccent' => false,
     ],
 ];
 ```
@@ -119,6 +120,9 @@ Specify the database connection that should be used to access indexed documents 
     // You can explicitly specify what PostgreSQL text search config to use by scout.
     // Use \dF in psql to see all available configurations in your database.
     'config' => 'english',
+    // See configuration instructions bellow
+    // For more information see https://www.postgresql.org/docs/current/static/unaccent.html
+    'unaccent' => false
 ],
 ...
 ```
@@ -132,6 +136,16 @@ To check the current value
 ```sql
 SHOW default_text_search_config;
 ```
+
+If the `unaccent`option is `true` you will need to create the extension.  
+```php
+// On the up() function of a migration
+DB::statement('CREATE EXTENSION unaccent');
+// And on the down function
+DB::statement('DROP EXTENSION IF EXISTS unaccent');
+```
+
+This options
 
 ### Prepare the Schema
 
@@ -149,13 +163,13 @@ class CreatePostsTable extends Migration
             $table->integer('user_id');
             $table->timestamps();
         });
-    
+
         DB::statement('ALTER TABLE posts ADD searchable tsvector NULL');
         DB::statement('CREATE INDEX posts_searchable_index ON posts USING GIN (searchable)');
         // Or alternatively
         // DB::statement('CREATE INDEX posts_searchable_index ON posts USING GIST (searchable)');
     }
-    
+
     public function down()
     {
         Schema::drop('posts');

--- a/src/PostgresEngine.php
+++ b/src/PostgresEngine.php
@@ -115,7 +115,11 @@ class PostgresEngine extends Engine
         // by the selected text search configuration which can be set globally in config/scout.php
         // file or individually for each model in searchableOptions()
         // See https://www.postgresql.org/docs/current/static/textsearch-controls.html
-        $vector = 'to_tsvector(COALESCE(?, get_current_ts_config()), ?)';
+        if ($this->config('unaccent') === true) {
+            $vector = 'to_tsvector(COALESCE(?, get_current_ts_config()), unaccent(?))';
+        } else {
+            $vector = 'to_tsvector(COALESCE(?, get_current_ts_config()), ?)';
+        }
 
         $select = $fields->map(function ($value, $key) use ($model, $vector, $bindings) {
             $bindings->push($this->searchConfig($model) ?: null)


### PR DESCRIPTION
Adds very basic support for the unaccent extension.
Maybe it will be better to extract the `to_tsvector` part on the `toVector` function to a separate function?
I am not sure how I would test this.