### PR TITLE
Downgrading version constraints to re-support PHP >= 7.0 and Laravel >= 5.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 php:
+  - 7.0
   - 7.1
   - 7.2
 

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "laravel/scout": "~4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~7.0",
+        "phpunit/phpunit": "~6.0",
         "mockery/mockery": "~1.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,11 @@
         }
     ],
     "require": {
-        "php": ">=7.1.3",
-        "illuminate/contracts": "5.6.*",
-        "illuminate/database": "5.6.*",
-        "illuminate/support": "5.6.*",
-        "laravel/scout": "4.*"
+        "php": ">=7.0",
+        "illuminate/contracts": "~5.4",
+        "illuminate/database": "~5.4",
+        "illuminate/support": "~5.4",
+        "laravel/scout": "~4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~7.0",


### PR DESCRIPTION
Because [Laravel Scout 4.0](https://github.com/laravel/scout/blob/v4.0.1/composer.json#L21) is compatible with PHP >= 7.0 and Laravel >= 5.4

For my projects, I'm mainly used the [LTS (5.5)](https://laravel.com/docs/5.5/releases#laravel-5.5) version of Laravel.
And with this pull request, I can use multiples `orderBy()` in my search, which is a `laravel-scout-postgres` [2.1.0](https://github.com/pmatseykanets/laravel-scout-postgres/releases/tag/v2.1.0) feature!

Related to: 85de4f2c4661d08353849ca1294640eccc50f0d8