### PR TITLE
Allow to customize the SQL search query

### DIFF
--- a/src/PostgresEngine.php
+++ b/src/PostgresEngine.php
@@ -280,7 +280,6 @@ class PostgresEngine extends Engine
      */
     protected function performSearch(Builder $builder, $perPage = 0, $page = 1)
     {
-
         list($query, $bindings) = $this->buildSearch($builder, $perPage, $page);
 
         return $this->database

--- a/src/PostgresEngine.php
+++ b/src/PostgresEngine.php
@@ -202,14 +202,14 @@ class PostgresEngine extends Engine
     }
 
     /**
-     * Perform the given search on the engine.
+     * Build the given search on the engine.
      *
      * @param \Laravel\Scout\Builder $builder
      * @param int|null $perPage
      * @param int $page
-     * @return array
+     * @return array [\Illuminate\Database\Schema\Builder $query, \Illuminate\Support\Collection $bindings]
      */
-    protected function performSearch(Builder $builder, $perPage = 0, $page = 1)
+    public function buildSearch(Builder $builder, $perPage = 0, $page = 1)
     {
         // We have to preserve the model in order to allow for
         // correct behavior of mapIds() method which currently
@@ -266,6 +266,22 @@ class PostgresEngine extends Engine
             $query->skip(($page - 1) * $perPage)
                 ->limit($perPage);
         }
+
+        return [$query, $bindings];
+    }
+
+    /**
+     * Perform the given search on the engine.
+     *
+     * @param \Laravel\Scout\Builder $builder
+     * @param int|null $perPage
+     * @param int $page
+     * @return array
+     */
+    protected function performSearch(Builder $builder, $perPage = 0, $page = 1)
+    {
+
+        list($query, $bindings) = $this->buildSearch($builder, $perPage, $page);
 
         return $this->database
             ->select($query->toSql(), $bindings->all());


### PR DESCRIPTION
NB: This pull request can be easily refactored, but I think this feature is really useful 😸 

Use case:
```php
$scoutEngine = App\Order::getModel()->searchableUsing();
list($query, $bindings) = $scoutEngine->buildSearch(
    App\Order::search('Star Trek')
);

// You can customize the SQL query here:
$query->addSelect('name');
// See: https://laravel.com/docs/5.6/queries

$orders = Illuminate\Support\Facades\DB::select($query->toSql(), $bindings->all());
```