### PR TITLE
Making querying method configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,17 +12,17 @@ This package makes it easy to use native PostgreSQL Full Text Search capabilitie
 ## Contents
 
 - [Installation](#installation)
-    - [Scout 4.x](#scout-4x)
-    - [Scout 2.x, 3.x](#scout-2x-3x)
-    - [Scout 1.x](#scout-1x)
-    - [Laravel](#laravel)
-    - [Lumen](#lumen)
+  - [Scout 4.x](#scout-4x)
+  - [Scout 2.x, 3.x](#scout-2x-3x)
+  - [Scout 1.x](#scout-1x)
+  - [Laravel](#laravel)
+  - [Lumen](#lumen)
 - [Configuration](#configuration)
-    - [Configuring the Engine](#configuring-the-engine)
-    - [Configuring PostgreSQL](#configuring-postgresql)
-    - [Prepare the Schema](#prepare-the-schema)
-    - [Configuring Searchable Data](#configuring-searchable-data)
-    - [Configuring the Model](#configuring-the-model)
+  - [Configuring the Engine](#configuring-the-engine)
+  - [Configuring PostgreSQL](#configuring-postgresql)
+  - [Prepare the Schema](#prepare-the-schema)
+  - [Configuring Searchable Data](#configuring-searchable-data)
+  - [Configuring the Model](#configuring-the-model)
 - [Usage](#usage)
 - [Testing](#testing)
 - [Security](#security)
@@ -36,22 +36,26 @@ This package makes it easy to use native PostgreSQL Full Text Search capabilitie
 You can install the package via composer:
 
 ### Scout 4.x (Laravel 5.4+)
+
 ``` bash
 composer require pmatseykanets/laravel-scout-postgres
 ```
 
 ### Scout 2.x, 3.x
+
 ``` bash
 composer require pmatseykanets/laravel-scout-postgres:1.0.0
 ```
 
 ### Scout 1.x
+
 ``` bash
 composer require pmatseykanets/laravel-scout-postgres:0.2.1
 ```
 
 
 ### Laravel
+
 If you're using Laravel < 5.5 or if you have package auto-discovery turned off you have to manually register the service provider:
 
 ```php
@@ -63,6 +67,7 @@ If you're using Laravel < 5.5 or if you have package auto-discovery turned off y
 ```
 
 ### Lumen
+
 Scout service provider uses `config_path` helper that is not included in the Lumen.
 To fix this include the following snippet either directly in `bootstrap.app` or in your autoloaded helpers file i.e. `app/helpers.php`.
 
@@ -82,6 +87,7 @@ if (! function_exists('config_path')) {
 ```
 
 Create the `scout.php` config file in `app/config` folder with the following contents
+
 ```php
 <?php
 
@@ -124,6 +130,10 @@ Specify the database connection that should be used to access indexed documents 
     // You can explicitly specify what PostgreSQL text search config to use by scout.
     // Use \dF in psql to see all available configurations in your database.
     'config' => 'english',
+    // You may set the default querying method
+    // Possible values: plainquery, phrasequery, tsquery
+    // plainquery is used if this option is omitted.
+    'search_using' => 'tsquery'
 ],
 ...
 ```
@@ -154,13 +164,13 @@ class CreatePostsTable extends Migration
             $table->integer('user_id');
             $table->timestamps();
         });
-    
+
         DB::statement('ALTER TABLE posts ADD searchable tsvector NULL');
         DB::statement('CREATE INDEX posts_searchable_index ON posts USING GIN (searchable)');
         // Or alternatively
         // DB::statement('CREATE INDEX posts_searchable_index ON posts USING GIST (searchable)');
     }
-    
+
     public function down()
     {
         Schema::drop('posts');
@@ -193,7 +203,7 @@ class Post extends Model
 {
     use Searchable;
 
-	...
+    // ...
     public function searchableOptions()
     {
         return [
@@ -244,7 +254,9 @@ public function searchableAdditionalArray()
     ];
 }
 ```
+
 You may want to make your searchable column hidden so it's not standing in your way
+
 ```php
 protected $hidden = [
     'searchable',
@@ -255,11 +267,10 @@ protected $hidden = [
 
 Please see the [official documentation](http://laravel.com/docs/master/scout) on how to use Laravel Scout.
 
-
 ## Testing
 
 ``` bash
-$ composer test
+composer test
 ```
 
 ## Security

--- a/src/PostgresEngine.php
+++ b/src/PostgresEngine.php
@@ -6,10 +6,10 @@ use Laravel\Scout\Builder;
 use Laravel\Scout\Engines\Engine;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Database\ConnectionResolverInterface;
-use ScoutEngines\Postgres\TsQuery\PhraseToTsQuery;
-use ScoutEngines\Postgres\TsQuery\PlainToTsQuery;
 use ScoutEngines\Postgres\TsQuery\ToTsQuery;
+use ScoutEngines\Postgres\TsQuery\PlainToTsQuery;
+use ScoutEngines\Postgres\TsQuery\PhraseToTsQuery;
+use Illuminate\Database\ConnectionResolverInterface;
 
 class PostgresEngine extends Engine
 {

--- a/src/PostgresEngine.php
+++ b/src/PostgresEngine.php
@@ -7,6 +7,9 @@ use Laravel\Scout\Engines\Engine;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\ConnectionResolverInterface;
+use ScoutEngines\Postgres\TsQuery\PhraseToTsQuery;
+use ScoutEngines\Postgres\TsQuery\PlainToTsQuery;
+use ScoutEngines\Postgres\TsQuery\ToTsQuery;
 
 class PostgresEngine extends Engine
 {
@@ -155,7 +158,7 @@ class PostgresEngine extends Engine
 
         $ids = $models->pluck($key)->all();
 
-        return $this->database
+        $this->database
             ->table($model->searchableAs())
             ->whereIn($key, $ids)
             ->update([$indexColumn => null]);
@@ -213,29 +216,20 @@ class PostgresEngine extends Engine
     {
         // We have to preserve the model in order to allow for
         // correct behavior of mapIds() method which currently
-        // does not revceive a model instance
+        // does not receive a model instance
         $this->preserveModel($builder->model);
 
         $bindings = collect([]);
 
-        // The choices of parser, dictionaries and which types of tokens to index are determined
-        // by the selected text search configuration which can be set globally in config/scout.php
-        // file or individually for each model in searchableOptions()
-        // See https://www.postgresql.org/docs/current/static/textsearch-controls.html
-        $tsQuery = 'plainto_tsquery(COALESCE(?, get_current_ts_config()), ?) AS query';
-        $bindings->push($this->searchConfig($builder->model) ?: null)
-            ->push($builder->query);
-
         $indexColumn = $this->getIndexColumn($builder->model);
 
-        // Build the query
+        // Build the SQL query
         $query = $this->database
             ->table($builder->index ?: $builder->model->searchableAs())
-            ->crossJoin($this->database->raw($tsQuery))
             ->select($builder->model->getKeyName())
             ->selectRaw("{$this->rankingExpression($builder->model, $indexColumn)} AS rank")
             ->selectRaw('COUNT(*) OVER () AS total_count')
-            ->whereRaw("$indexColumn @@ query");
+            ->whereRaw("$indexColumn @@ \"tsquery\"");
 
         // Apply where clauses that were set on the builder instance if any
         foreach ($builder->wheres as $key => $value) {
@@ -267,8 +261,43 @@ class PostgresEngine extends Engine
                 ->limit($perPage);
         }
 
+        // The choices of parser, dictionaries and which types of tokens to index are determined
+        // by the selected text search configuration which can be set globally in config/scout.php
+        // file or individually for each model in searchableOptions()
+        // See https://www.postgresql.org/docs/current/static/textsearch-controls.html
+        $tsQuery = $builder->callback
+            ? call_user_func($builder->callback, $builder, $this->searchConfig($builder->model))
+            : $this->defaultQueryMethod($builder->query, $this->searchConfig($builder->model));
+
+        $query->crossJoin($this->database->raw($tsQuery->sql().' AS "tsquery"'));
+
+        // Transfer bindings
+        foreach ($tsQuery->bindings() as $binding) {
+            $bindings->prepend($binding);
+        }
+
         return $this->database
             ->select($query->toSql(), $bindings->all());
+    }
+
+    /**
+     * Returns the default query method.
+     *
+     * @param string $query
+     * @param string $config
+     * @return \ScoutEngines\Postgres\TsQuery\TsQueryable
+     */
+    public function defaultQueryMethod($query, $config)
+    {
+        switch (strtolower($this->config('search_using', 'plain'))) {
+            case 'tsquery':
+                return new ToTsQuery($query, $config);
+            case 'phrasequery':
+                return new PhraseToTsQuery($query, $config);
+            case 'plainquery':
+            default:
+                return new PlainToTsQuery($query, $config);
+        }
     }
 
     /**
@@ -345,7 +374,7 @@ class PostgresEngine extends Engine
      */
     protected function rankingExpression(Model $model, $indexColumn)
     {
-        $args = collect([$indexColumn, 'query']);
+        $args = collect([$indexColumn, '"tsquery"']);
 
         if ($weights = $this->rankWeights($model)) {
             $args->prepend("'$weights'");
@@ -504,7 +533,7 @@ class PostgresEngine extends Engine
      */
     protected function searchConfig(Model $model)
     {
-        return $this->option($model, 'config', $this->config('config', ''));
+        return $this->option($model, 'config', $this->config('config', '')) ?: null;
     }
 
     /**

--- a/src/PostgresEngineServiceProvider.php
+++ b/src/PostgresEngineServiceProvider.php
@@ -2,15 +2,50 @@
 
 namespace ScoutEngines\Postgres;
 
+use Laravel\Scout\Builder;
 use Laravel\Scout\EngineManager;
 use Illuminate\Support\ServiceProvider;
+use ScoutEngines\Postgres\TsQuery\PhraseToTsQuery;
+use ScoutEngines\Postgres\TsQuery\PlainToTsQuery;
+use ScoutEngines\Postgres\TsQuery\RawQuery;
+use ScoutEngines\Postgres\TsQuery\ToTsQuery;
 
 class PostgresEngineServiceProvider extends ServiceProvider
 {
     public function boot()
     {
-        app(EngineManager::class)->extend('pgsql', function () {
-            return new PostgresEngine($this->app['db'], config('scout.pgsql', []));
+        $this->app->make(EngineManager::class)->extend('pgsql', function () {
+            return new PostgresEngine($this->app['db'], $this->app['config']->get('scout.pgsql', []));
         });
+
+        if (! Builder::hasMacro('usingPhraseQuery')) {
+            Builder::macro('usingPhraseQuery', function () {
+                $this->callback = function ($builder, $config) {
+                    return new PhraseToTsQuery($builder->query, $config);
+                };
+
+                return $this;
+            });
+        }
+
+        if (! Builder::hasMacro('usingPlainQuery')) {
+            Builder::macro('usingPlainQuery', function () {
+                $this->callback = function ($builder, $config) {
+                    return new PlainToTsQuery($builder->query, $config);
+                };
+
+                return $this;
+            });
+        }
+
+        if (! Builder::hasMacro('usingTsQuery')) {
+            Builder::macro('usingTsQuery', function () {
+                $this->callback = function ($builder, $config) {
+                    return new ToTsQuery($builder->query, $config);
+                };
+
+                return $this;
+            });
+        }
     }
 }

--- a/src/PostgresEngineServiceProvider.php
+++ b/src/PostgresEngineServiceProvider.php
@@ -5,10 +5,9 @@ namespace ScoutEngines\Postgres;
 use Laravel\Scout\Builder;
 use Laravel\Scout\EngineManager;
 use Illuminate\Support\ServiceProvider;
-use ScoutEngines\Postgres\TsQuery\PhraseToTsQuery;
-use ScoutEngines\Postgres\TsQuery\PlainToTsQuery;
-use ScoutEngines\Postgres\TsQuery\RawQuery;
 use ScoutEngines\Postgres\TsQuery\ToTsQuery;
+use ScoutEngines\Postgres\TsQuery\PlainToTsQuery;
+use ScoutEngines\Postgres\TsQuery\PhraseToTsQuery;
 
 class PostgresEngineServiceProvider extends ServiceProvider
 {

--- a/src/TsQuery/BaseTsQueryable.php
+++ b/src/TsQuery/BaseTsQueryable.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace ScoutEngines\Postgres\TsQuery;
+
+abstract class BaseTsQueryable implements TsQueryable
+{
+    /**
+     * Text Search Query.
+     *
+     * @var string
+     */
+    public $query;
+
+    /**
+     * PostgreSQL Text search configuration.
+     *
+     * @var string|null
+     */
+    public $config;
+
+    /**
+     * PostgreSQL Text Search Function.
+     *
+     * @var string
+     */
+    protected $tsFunction = '';
+
+    /**
+     * Create a new instance.
+     *
+     * @param string $query
+     * @param string $config
+     */
+    public function __construct($query, $config = null)
+    {
+        $this->query = $query;
+        $this->config = $config;
+    }
+
+    /**
+     * Render the SQL representation.
+     *
+     * @return string
+     */
+    public function sql()
+    {
+        return sprintf('%s(COALESCE(?, get_current_ts_config()), ?)', $this->tsFunction);
+    }
+
+    /**
+     * Return value bindings for the SQL representation.
+     *
+     * @return array
+     */
+    public function bindings()
+    {
+        return [$this->query, $this->config];
+    }
+}

--- a/src/TsQuery/PhraseToTsQuery.php
+++ b/src/TsQuery/PhraseToTsQuery.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace ScoutEngines\Postgres\TsQuery;
+
+class PhraseToTsQuery extends BaseTsQueryable
+{
+    protected $tsFunction = 'phraseto_tsquery';
+}

--- a/src/TsQuery/PlainToTsQuery.php
+++ b/src/TsQuery/PlainToTsQuery.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace ScoutEngines\Postgres\TsQuery;
+
+class PlainToTsQuery extends BaseTsQueryable
+{
+    protected $tsFunction = 'plainto_tsquery';
+}

--- a/src/TsQuery/ToTsQuery.php
+++ b/src/TsQuery/ToTsQuery.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace ScoutEngines\Postgres\TsQuery;
+
+class ToTsQuery extends BaseTsQueryable
+{
+    protected $tsFunction = 'to_tsquery';
+}

--- a/src/TsQuery/TsQueryable.php
+++ b/src/TsQuery/TsQueryable.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace ScoutEngines\Postgres\TsQuery;
+
+interface TsQueryable
+{
+    /**
+     * Render the SQL representation.
+     *
+     * @return string
+     */
+    public function sql();
+
+    /**
+     * Return value bindings for the SQL representation.
+     *
+     * @return array
+     */
+    public function bindings();
+}

--- a/tests/PostgresEngineTest.php
+++ b/tests/PostgresEngineTest.php
@@ -200,7 +200,7 @@ class PostgresEngineTest extends TestCase
         $model->shouldReceive('get')->once()->andReturn(Collection::make([new TestModel()]));
 
         $results = $engine->map(
-            json_decode('[{"id": 1, "rank": 0.33, "total_count": 1}]'), $model);
+            json_decode('[{"id": 1, "tsrank": 0.33, "total_count": 1}]'), $model);
 
         $this->assertCount(1, $results);
     }
@@ -219,7 +219,7 @@ class PostgresEngineTest extends TestCase
         $model->shouldReceive('get')->once()->andReturn(Collection::make([$expectedModel]));
 
         $models = $engine->map(
-            json_decode('[{"id": 1, "rank": 0.33, "total_count": 2}, {"id": 2, "rank": 0.31, "total_count": 2}]'), $model);
+            json_decode('[{"id": 1, "tsrank": 0.33, "total_count": 2}, {"id": 2, "tsrank": 0.31, "total_count": 2}]'), $model);
 
         $this->assertCount(1, $models);
         $this->assertEquals(2, $models->first()->id);
@@ -230,7 +230,7 @@ class PostgresEngineTest extends TestCase
         list($engine) = $this->getEngine();
 
         $count = $engine->getTotalCount(
-            json_decode('[{"id": 1, "rank": 0.33, "total_count": 100}]')
+            json_decode('[{"id": 1, "tsrank": 0.33, "total_count": 100}]')
         );
 
         $this->assertEquals(100, $count);
@@ -269,17 +269,17 @@ class PostgresEngineTest extends TestCase
         $db->shouldReceive('table')
             ->andReturn($table = Mockery::mock('stdClass'));
         $db->shouldReceive('raw')
-            ->with('plainto_tsquery(COALESCE(?, get_current_ts_config()), ?) AS query')
-            ->andReturn('plainto_tsquery(COALESCE(?, get_current_ts_config()), ?) AS query');
+            ->with('plainto_tsquery(COALESCE(?, get_current_ts_config()), ?) AS "tsquery"')
+            ->andReturn('plainto_tsquery(COALESCE(?, get_current_ts_config()), ?) AS "tsquery"');
 
         $table->shouldReceive('crossJoin')
-                ->with('plainto_tsquery(COALESCE(?, get_current_ts_config()), ?) AS query')
+                ->with('plainto_tsquery(COALESCE(?, get_current_ts_config()), ?) AS "tsquery"')
                 ->andReturnSelf()
             ->shouldReceive('select')
                 ->with('id')
                 ->andReturnSelf()
             ->shouldReceive('selectRaw')
-                ->with('ts_rank(searchable,query) AS rank')
+                ->with('ts_rank(searchable,"tsquery") AS rank')
                 ->andReturnSelf()
             ->shouldReceive('selectRaw')
                 ->with('COUNT(*) OVER () AS total_count')


### PR DESCRIPTION
This long coming PR should hopefully address #10 and #14 

```php
// plainto_tsquery()
$results = App\Post::search('cat rat')->usingPlainQuery()->get()

// plainto_tsquery()
$results = App\Post::search('cat rat')->usingPhraseQuery()->get()

// to_tsquery()
$results = App\Post::search('fat & (cat | rat)')->usingTsQuery()->get()

// DYI using a callback
use ScoutEngines\Postgres\TsQuery\ToTsQuery;

$results = App\Post::search('fat & (cat | rat)', function ($builder, $config) {
    return new ToTsQuery($builder->query, $config);
})->get();
```

It's possible to configure the default querying method in `scout.php`

```php
    'pgsql' => [
        'connection' => 'pgsql',
        'maintain_index' => true,
        'search_config' => 'english',
        // Possible values are plainquery|phrasequery|tsquery. Default - plainquery
        'search_using' => 'tsquery',
    ],
```