### PR TITLE
Allow to customize the SQL search query with Closure v2

### DIFF
--- a/src/PostgresEngine.php
+++ b/src/PostgresEngine.php
@@ -2,6 +2,7 @@
 
 namespace ScoutEngines\Postgres;
 
+use Closure;
 use Laravel\Scout\Builder;
 use Laravel\Scout\Engines\Engine;
 use Illuminate\Database\Eloquent\Model;
@@ -35,6 +36,11 @@ class PostgresEngine extends Engine
      * @var \Illuminate\Database\Eloquent\Model
      */
     protected $model;
+
+    /**
+     * @var \Closure
+     */
+    protected $queryClosure;
 
     /**
      * Create a new instance of PostgresEngine.
@@ -202,6 +208,19 @@ class PostgresEngine extends Engine
     }
 
     /**
+     * "Extend" the SQL search query.
+     *
+     * @param  \Closure  $closure
+     * @return void
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function extendQuery(Closure $closure)
+    {
+        $this->queryClosure = $closure;
+    }
+
+    /**
      * Perform the given search on the engine.
      *
      * @param \Laravel\Scout\Builder $builder
@@ -265,6 +284,10 @@ class PostgresEngine extends Engine
         if ($perPage > 0) {
             $query->skip(($page - 1) * $perPage)
                 ->limit($perPage);
+        }
+
+        if ($this->queryClosure instanceof Closure) {
+            $this->queryClosure->call($this, $query, $bindings);
         }
 
         return $this->database

--- a/src/PostgresEngine.php
+++ b/src/PostgresEngine.php
@@ -285,7 +285,10 @@ class PostgresEngine extends Engine
         }
 
         if ($this->queryClosure instanceof Closure) {
-            $this->queryClosure->call($this, $query, $bindings);
+            $this->queryClosure->call($this, $query);
+            foreach ($query->getBindings() as $binding) {
+                $bindings->push($binding);
+            }
         }
 
         return $this->database

--- a/src/PostgresEngine.php
+++ b/src/PostgresEngine.php
@@ -212,8 +212,6 @@ class PostgresEngine extends Engine
      *
      * @param  \Closure  $closure
      * @return void
-     *
-     * @throws \InvalidArgumentException
      */
     public function extendQuery(Closure $closure)
     {


### PR DESCRIPTION
**Notice:** This pull request is a refactoring of my second pull request https://github.com/pmatseykanets/laravel-scout-postgres/pull/19
Without the need of the `$bindings` variable.

Use case:
```php
App\User::getModel()->searchableUsing()->extendQuery(function ($query) {
    return $query
        ->addSelect('name')
        ->where('organization_name', 'GitHub')
        ->whereIn('role', ['admin', 'moderator'])
        ->whereYear('created_at', '>', date('Y') - 2);
});
$users= App\User::search('Peter')->raw();
```