### PR TITLE
Refactoring bindings in PostgresEngine::performSearch() method

### DIFF
--- a/src/PostgresEngine.php
+++ b/src/PostgresEngine.php
@@ -219,8 +219,6 @@ class PostgresEngine extends Engine
         // does not receive a model instance
         $this->preserveModel($builder->model);
 
-        $bindings = collect([]);
-
         $indexColumn = $this->getIndexColumn($builder->model);
 
         // Build the SQL query
@@ -234,7 +232,6 @@ class PostgresEngine extends Engine
         // Apply where clauses that were set on the builder instance if any
         foreach ($builder->wheres as $key => $value) {
             $query->where($key, $value);
-            $bindings->push($value);
         }
 
         // If parsed documents are being stored in the model's table
@@ -270,14 +267,10 @@ class PostgresEngine extends Engine
             : $this->defaultQueryMethod($builder->query, $this->searchConfig($builder->model));
 
         $query->crossJoin($this->database->raw($tsQuery->sql().' AS "tsquery"'));
-
-        // Transfer bindings
-        foreach ($tsQuery->bindings() as $binding) {
-            $bindings->prepend($binding);
-        }
+        $query->addBinding($tsQuery->bindings(), 'join');
 
         return $this->database
-            ->select($query->toSql(), $bindings->all());
+            ->select($query->toSql(), $query->getBindings());
     }
 
     /**

--- a/src/PostgresEngine.php
+++ b/src/PostgresEngine.php
@@ -267,6 +267,7 @@ class PostgresEngine extends Engine
             : $this->defaultQueryMethod($builder->query, $this->searchConfig($builder->model));
 
         $query->crossJoin($this->database->raw($tsQuery->sql().' AS "tsquery"'));
+        // Add TS bindings to the query
         $query->addBinding($tsQuery->bindings(), 'join');
 
         return $this->database

--- a/src/TsQuery/BaseTsQueryable.php
+++ b/src/TsQuery/BaseTsQueryable.php
@@ -54,6 +54,6 @@ abstract class BaseTsQueryable implements TsQueryable
      */
     public function bindings()
     {
-        return [$this->query, $this->config];
+        return [$this->config, $this->query];
     }
 }


### PR DESCRIPTION
- To preserve order of binding insertion
- To handle bindings in a more Laravel way