### PR TITLE
Add PHP8 to supported versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,10 @@ jobs:
             laravel: ^8.0
           - laravel: ^8.0
             scout: ^7.0
+          - php: 8.0
+            laravel: ^6.0
+          - php: 8.0
+            laravel: ^7.0
 
     name: Test PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - Scout ${{ matrix.scout }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.2, 7.3, 7.4]
+        php: [7.2, 7.3, 7.4, 8.0]
         laravel: [^6.0, ^7.0, ^8.0]
         scout: [^7.0, ^8.0]
         exclude:

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2|^8.0",
         "illuminate/contracts": "~6.0|~7.0|~8.0",
         "illuminate/database": "~6.0|~7.0|~8.0",
         "illuminate/support": "~6.0|~7.0|~8.0",


### PR DESCRIPTION
Tests pass on PHP 8 when running them locally

Have configured the PHP8 tests in the action to only run for Laravel 8 with Scout v8.