### PR TITLE
feat: accept callable for search config option

### DIFF
--- a/src/PostgresEngine.php
+++ b/src/PostgresEngine.php
@@ -529,7 +529,13 @@ class PostgresEngine extends Engine
      */
     protected function searchConfig(Model $model)
     {
-        return $this->option($model, 'config', $this->config('config', '')) ?: null;
+        $searchConfig = $this->option($model, 'config', $this->config('config', ''));
+
+        if (is_callable($searchConfig)) {
+            $searchConfig = $searchConfig($model);
+        }
+
+        return $searchConfig;
     }
 
     /**


### PR DESCRIPTION
This PR will add the possibility to use a callback for the `$config` parameter. Having this it will allow you to support dynamic languages:
````php
        'config' => function ($model) {
            return $model->language;
        },
````

This will probably solve https://github.com/pmatseykanets/laravel-scout-postgres/issues/42 as well.